### PR TITLE
send circuit

### DIFF
--- a/circuits/circuits/send.circom
+++ b/circuits/circuits/send.circom
@@ -106,13 +106,13 @@ template Validate(levels) {
         // Signals used in LessThan need to be range checked to avoid a subtle overflow bug demonstrated here https://github.com/BlakeMScurr/comparator-overflow
         // Note; users must *not* be allowed to force transactions where the coin values exceed 128 bits and therefore don't pass the range check,
         // or they'll be able to halt and break the system. TODO: ensure this is enforced by the smart contracts
-        component coin_range_checks[3];
-        for (var i = 0; i < 3; i++) {
+        // highest_coin_to_send is enforced to fit in 128 bits in smart contract.
+        component coin_range_checks[2];
+        for (var i = 0; i < 2; i++) {
             coin_range_checks[i] = Num2Bits(128);
         }
-        coin_range_checks[0].in <== highest_coin_to_send;
-        coin_range_checks[1].in <== leaf_coins[0];
-        coin_range_checks[2].in <== leaf_coins[1];
+        coin_range_checks[0].in <== leaf_coins[0];
+        coin_range_checks[1].in <== leaf_coins[1];
     }
 
     // If the sent coins are valid (i.e., in bounds and in order), then the operator must provide a merkle proof for *some* coins in that range.

--- a/circuits/circuits/send.circom
+++ b/circuits/circuits/send.circom
@@ -9,13 +9,19 @@ template Send(levels) {
     signal input recipient;
     signal input initial_root;
 
+    signal input leaf_coins[2];
+    signal input pathElements[levels];
+    signal input pathIndices[levels];
+
     signal output new_root;
 
-    // make sure it's a send request by checking sender and recipient is non-zero
-    signal is_sender_zero <== IsZero(in <== sender);
-    is_sender_zero === 0;
-    signal is_recipient_zero <== IsZero(in <== recipient);
-    is_recipient_zero === 0;
+    {
+        // make sure it's a send request by checking sender and recipient is non-zero
+        signal is_sender_zero <== IsZero()(in <== sender);
+        is_sender_zero === 0;
+        signal is_recipient_zero <== IsZero()(in <== recipient);
+        is_recipient_zero === 0;
+    }
 
     // To process a transaction we:
     // - Delete the old leaf
@@ -23,12 +29,12 @@ template Send(levels) {
     // - Merge up to 3 adjacent new leaves
     //
     // We then output the new root from the circuit
-    component transaction_is_valid = Validate();
+    signal is_transaction_valid = Validate()();
 
     signal next_root = 0; // TODO
 
     // If the transaction was valid output next_root, otherwise output the initial_root
-    new_root <== (next_root - initial_root) * transaction_is_valid.out + initial_root;
+    new_root <== (next_root - initial_root) * is_transaction_valid + initial_root;
 }
 
 // A send transaction is invalid if:
@@ -53,88 +59,79 @@ template Validate() {
     signal input pathElements[levels];
     signal input pathIndices[levels];
 
-    signal output send_is_valid;
+    signal output is_send_valid;
 
-    signal signature_is_valid <== 0; // TODO
+    signal is_signature_valid <== 0; // TODO
     signal signer <== 0; // TODO: recover signer from signature, or just pass it in as input
 
-    // The coin range is invalid if it's out of order or out of bounds
-    component coins_in_order LessThan(128);
+    // The coin range is invalid if it's out of order or out of bounds.
+    component coins_in_order = LessThan(128);
     coins_in_order.in[0] <== sent_coins[0];
     coins_in_order.in[1] <== sent_coins[1];
 
-    component coins_in_bounds LessEqThan(128);
+    component coins_in_bounds = LessEqThan(128);
     coins_in_bounds.in[0] <== sent_coins[1];
     coins_in_bounds.in[1] <== highest_coin;
 
-    // Signals used in LessThan need to be range checked to avoid a subtle overflow bug demonstrated here https://github.com/BlakeMScurr/comparator-overflow
-    // Note; users must *not* be allowed to force transactions where the coin values exceed 128 bits and therefore don't pass the range check,
-    // or they'll be able to halt and break the system. TODO: ensure this is enforced by the smart contracts
-    component coin_range_checks[5];
-    for (var i = 0; i < 5; i++) {
-        coin_range_checks[i] = Num2Bits(128);
+    {
+        // Signals used in LessThan need to be range checked to avoid a subtle overflow bug demonstrated here https://github.com/BlakeMScurr/comparator-overflow
+        // Note; users must *not* be allowed to force transactions where the coin values exceed 128 bits and therefore don't pass the range check,
+        // or they'll be able to halt and break the system. TODO: ensure this is enforced by the smart contracts
+        component coin_range_checks[5];
+        for (var i = 0; i < 5; i++) {
+            coin_range_checks[i] = Num2Bits(128);
+        }
+        coin_range_checks[0].in <== sent_coins[0];
+        coin_range_checks[1].in <== sent_coins[1];
+        coin_range_checks[2].in <== highest_coin;
+        coin_range_checks[3].in <== leaf_coins[0];
+        coin_range_checks[4].in <== leaf_coins[1];
     }
-    coin_range_checks[0].in <== sent_coins[0];
-    coin_range_checks[1].in <== sent_coins[1];
-    coin_range_checks[2].in <== highest_coin;
-    coin_range_checks[3].in <== leaf_coins[0];
-    coin_range_checks[4].in <== leaf_coins[1];
 
     // If the sent coins are valid (i.e., in bounds and in order), then the operator must provide a merkle proof for *some* coins in that range.
     // Since adjacent coin ranges with the same owner are always consolidated, we know that if the sender truly owns all the coins in the sent range,
     // then the leaf coins will owned by them and will be a superset of the spent range.
 
-    // Validate the Merkle proof
-    component leaf = Poseidon(3);
-    leaf.in[0] <== owner;
-    leaf.in[1] <== leaf_coins[0];
-    leaf.in[2] <== leaf_coins[1];
-
-    component merkle_proof_checker CheckMerkleProof(levels);
-    merkle_proof_checker.leaf <== leaf;
-    for (var i = 0; i < levels; i++) {
-        merkle_proof_checker.pathElements[i] <== pathElements[i];
-        merkle_proof_checker.pathIndices[i] <== pathIndices[i];
+    {
+        // Validate the Merkle proof
+        signal initial_root_calculated <== CheckMerkleProof(levels)(
+            leaf <== Poseidon(3)(inputs <== [owner, leaf_coins[0], leaf_coins[1]]),
+            pathElements <== pathElements,
+            pathIndices <== pathIndices
+        );
+        initial_root_calculated === initial_root;
     }
-    merkle_proof_checker.root === initial_root;
 
     // Require overlap between leaf coins and sent coins, if the sent coins are valid
-    component coin_ranges_overlap = CoinRangesOverlap();
-    for (var i = 0; i < 2; i++) {
-        coin_ranges_overlap.a[i] <== leaf_coins[i];
-        coin_ranges_overlap.b[i] <== sent_coins[i];
-    }
-    (1 - coin_ranges_overlap.out) * sent_coins_valid === 0; // If the sent coins are valid, the sent coins and leaf coins have to overlap
+    signal is_coin_ranges_overlap <== CoinRangesOverlap()(
+        a <== leaf_coins,
+        b <== sent_coins
+    );
+
+    (1 - is_coin_ranges_overlap) * sent_coins_valid === 0; // If the sent coins are valid, the sent coins and leaf coins have to overlap
 
     // Check that the leaf coins are owned by the signer and contain the sent coins
-    component leaf_cointains_sent = CoinRangeContains();
-    for (var i = 0; i < 2; i++) {
-        leaf_cointains_sent.superset[i] <== leaf_coins[i];
-        leaf_cointains_sent.subset[i] <== sent_coins[i];
-    }
+    signal is_leaf_cointains_sent <== CoinRangeContains()(
+        superset <== leaf_coins,
+        subset <== sent_coins
+    );
 
-    component signer_is_owner = IsEqual();
-    signer_is_owner.in[0] <== signer;
-    signer_is_owner.in[1] <== owner;
+    signal is_signer_owner <== IsEqual()(in <== [signer, owner]);
 
     // Check if all conditions for transaction validity hold
-    component transaction_is_valid = MultiAND(5);
-    transaction_is_valid.in[0] <== signature_is_valid;
-    transaction_is_valid.in[1] <== coins_in_order.out;
-    transaction_is_valid.in[2] <== coins_in_bounds.out;
-    transaction_is_valid.in[3] <== leaf_contains_sent.out;
-    transaction_is_valid.in[4] <== signer_is_owner.out;
-
-    send_is_valid <== transaction_is_valid.out;
+    is_send_valid <== MultiAND(5)(
+        in <== [is_signature_valid, coins_in_order.out, coins_in_bounds.out, is_leaf_cointains_sent, is_signer_owner]
+    );
 }
 
 // Checks whether one coin range contains another
 // I.e., [10, 20] contains [10, 20], [11, 20], and [15, 15] but doesn't contain
-// [1, 5], [5, 11], [9, 11], or [15, 21]
+// [1, 5], [5, 11], [9, 11], or [15, 21].
+// Assumes that all inputs fit in 128 bits.
 template CoinRangeContains() {
     signal input superset[2];
     signal input subset[2];
-    signal output contains;
+    signal output out;
 
     component check_low = LessEqThan(128);
     check_low[0].in <== superset[0];
@@ -144,12 +141,13 @@ template CoinRangeContains() {
     check_high[0].in <== superset[1];
     check_high[1].in <== subset[1];
 
-    contains <== check_low.out * check_high.out;
+    out <== check_low.out * check_high.out;
 }
 
 // Checks whether two coin ranges overlap
 // I.e, [1, 10] overlaps with [5, 10], [5, 15], and [10, 20], but doesn't overlap
-// with [11, 20] or [20, 50]
+// with [11, 20] or [20, 50].
+// Assumes that all inputs fit in 128 bits.
 template CoinRangesOverlap() {
     signal input a[2];
     signal input b[2];
@@ -176,7 +174,7 @@ template CoinRangesOverlap() {
 
     component ranges_overlap = MultiAND(4);
     for (var i = 0; i < 4; i++) {
-        ranges_overlap[i] <== overlap_checks[i];
+        ranges_overlap[i].in[0] <== overlap_checks[i].out;
     }
 
     out <== ranges_overlap.out;
@@ -187,15 +185,12 @@ template MultiAND(n) {
     signal input in[n];
     signal output out;
 
-    let sum = 0;
+    var sum = 0;
     for (var i = 0; i < n; i++) {
         sum += in[i];
     }
 
-    component sumcheck = IsEqual();
-    sumcheck.in[0] <== sum;
-    sumcheck.in[1] <== n;
-    out <== sumcheck.out;
+    out <== IsEqual()(in <== [sum, n]);
 }
 
 template EditTree() {}

--- a/circuits/circuits/send.circom
+++ b/circuits/circuits/send.circom
@@ -13,6 +13,12 @@ template Send(levels) {
     signal input pathElements[levels];
     signal input pathIndices[levels];
 
+    signal input highest_coin_to_send; // sending [leaf_coins[0], highest_coin_to_send]
+    signal input signature;
+
+    signal input pathElementsForZero[levels];
+    signal input pathIndicesForZero[levels];
+
     signal output new_root;
 
     {
@@ -25,16 +31,49 @@ template Send(levels) {
 
     // To process a transaction we:
     // - Delete the old leaf
-    // - Insert up to 3 new leaves
-    // - Merge up to 3 adjacent new leaves
+    // - Insert 2 new leaves
     //
     // We then output the new root from the circuit
-    signal is_transaction_valid = Validate()();
+    signal is_transaction_valid = Validate()(
+        initial_root <== initial_root,
+        highest_coin_to_send <== highest_coin_to_send,
+        signature <== signature,
+        owner <== sender,
+        leaf_coins <== leaf_coins,
+        pathElements <== pathElements,
+        pathIndices <== pathIndices
+    );
 
-    signal next_root = 0; // TODO
+    // determine the new leaf corresponding to sender.
+    // If sending all coins, we replace it with 0; otherwise we replace it with the remaining coins.
+    signal is_send_all <== IsEqual(in <== [highest_coin_to_send, leaf_coins[1]]);
+    signal sender_coin_leaf <== Poseidon(3)(inputs <== [sender, highest_coin_to_send+1, leaf_coins[1]]);
+    signal sender_leaf <== (1 - is_send_all) * sender_coin_leaf;
+
+    signal send_root <== CheckMerkleProof(levels)(
+        leaf <== sender_leaf,
+        pathElements <== pathElements,
+        pathIndices <== pathIndices
+    );
+
+    // insert the leaf for recipient.
+    // To do that, verify if the zero leaf is included in the new root with updated sender leaf.
+    // Then insert recipient leaf.
+    signal send_root_calculated <== CheckMerkleProof(levels)(
+        leaf <== 0,
+        pathElements <== pathElementsForZero,
+        pathIndices <== pathIndicesForZero
+    );
+    send_root_calculated === send_root;
+
+    signal receive_root <== CheckMerkleProof(levels)(
+        leaf <== Poseidon(3)(inputs <== [recipient, leaf_coins[0], highest_coin_to_send]),
+        pathElements <== pathElementsForZero,
+        pathIndices <== pathIndicesForZero
+    )
 
     // If the transaction was valid output next_root, otherwise output the initial_root
-    new_root <== (next_root - initial_root) * is_transaction_valid + initial_root;
+    new_root <== (receive_root - initial_root) * is_transaction_valid + initial_root;
 }
 
 // A send transaction is invalid if:
@@ -45,12 +84,10 @@ template Send(levels) {
 template Validate() {
     // public inputs
     signal initial_root;
-    signal highest_coin;
 
     // private inputs
     // tx
-    signal input recipient;
-    signal input sent_coins[2];
+    signal input highest_coin_to_send; // sending [leaf_coins[0], highest_coin_to_send]
     signal input signature;
 
     // relevant state
@@ -59,19 +96,11 @@ template Validate() {
     signal input pathElements[levels];
     signal input pathIndices[levels];
 
+
     signal output is_send_valid;
 
     signal is_signature_valid <== 0; // TODO
     signal signer <== 0; // TODO: recover signer from signature, or just pass it in as input
-
-    // The coin range is invalid if it's out of order or out of bounds.
-    component coins_in_order = LessThan(128);
-    coins_in_order.in[0] <== sent_coins[0];
-    coins_in_order.in[1] <== sent_coins[1];
-
-    component coins_in_bounds = LessEqThan(128);
-    coins_in_bounds.in[0] <== sent_coins[1];
-    coins_in_bounds.in[1] <== highest_coin;
 
     {
         // Signals used in LessThan need to be range checked to avoid a subtle overflow bug demonstrated here https://github.com/BlakeMScurr/comparator-overflow
@@ -81,8 +110,6 @@ template Validate() {
         for (var i = 0; i < 5; i++) {
             coin_range_checks[i] = Num2Bits(128);
         }
-        coin_range_checks[0].in <== sent_coins[0];
-        coin_range_checks[1].in <== sent_coins[1];
         coin_range_checks[2].in <== highest_coin;
         coin_range_checks[3].in <== leaf_coins[0];
         coin_range_checks[4].in <== leaf_coins[1];
@@ -102,82 +129,38 @@ template Validate() {
         initial_root_calculated === initial_root;
     }
 
-    // Require overlap between leaf coins and sent coins, if the sent coins are valid
-    signal is_coin_ranges_overlap <== CoinRangesOverlap()(
-        a <== leaf_coins,
-        b <== sent_coins
-    );
-
-    (1 - is_coin_ranges_overlap) * sent_coins_valid === 0; // If the sent coins are valid, the sent coins and leaf coins have to overlap
-
     // Check that the leaf coins are owned by the signer and contain the sent coins
     signal is_leaf_cointains_sent <== CoinRangeContains()(
-        superset <== leaf_coins,
-        subset <== sent_coins
+        set <== leaf_coins,
+        point <== highest_coin_to_send
     );
 
     signal is_signer_owner <== IsEqual()(in <== [signer, owner]);
 
     // Check if all conditions for transaction validity hold
-    is_send_valid <== MultiAND(5)(
-        in <== [is_signature_valid, coins_in_order.out, coins_in_bounds.out, is_leaf_cointains_sent, is_signer_owner]
+    is_send_valid <== MultiAND(3)(
+        in <== [is_signature_valid, is_leaf_cointains_sent, is_signer_owner]
     );
 }
 
-// Checks whether one coin range contains another
-// I.e., [10, 20] contains [10, 20], [11, 20], and [15, 15] but doesn't contain
-// [1, 5], [5, 11], [9, 11], or [15, 21].
+// Checks whether a number is in a set.
+// I.e., [10, 20] contains 10, 11, 20 but doesn't contain
+// 8, 9, 21.
 // Assumes that all inputs fit in 128 bits.
 template CoinRangeContains() {
-    signal input superset[2];
-    signal input subset[2];
+    signal input set[2];
+    signal input point;
     signal output out;
 
     component check_low = LessEqThan(128);
     check_low[0].in <== superset[0];
-    check_low[1].in <== subset[0];
+    check_low[1].in <== point;
 
     component check_high = GreaterEqThan(128);
     check_high[0].in <== superset[1];
-    check_high[1].in <== subset[1];
+    check_high[1].in <== point;
 
     out <== check_low.out * check_high.out;
-}
-
-// Checks whether two coin ranges overlap
-// I.e, [1, 10] overlaps with [5, 10], [5, 15], and [10, 20], but doesn't overlap
-// with [11, 20] or [20, 50].
-// Assumes that all inputs fit in 128 bits.
-template CoinRangesOverlap() {
-    signal input a[2];
-    signal input b[2];
-    signal output out;
-
-    // If the two ranges overlap, then the higher of the two lower bounds will be in both ranges
-    signal common_coin <-- a[0] > b[0] ? a[0] : b[0];
-    component overlap_checks[4];
-    for (var i = 0; i < 4; i++) {
-        overlap_checks[i] = LessEqThan(128);
-    }
-
-    // Verifies that the common coin is in the first range
-    overlap_checks[0].in[0] <== a[0];
-    overlap_checks[0].in[1] <== common_coin;
-    overlap_checks[1].in[0] <== common_coin;
-    overlap_checks[1].in[1] <== a[1];
-
-    // Verifies that the common coin is in the second range
-    overlap_checks[2].in[0] <== b[0];
-    overlap_checks[2].in[1] <== common_coin;
-    overlap_checks[3].in[0] <== common_coin;
-    overlap_checks[3].in[1] <== b[1];
-
-    component ranges_overlap = MultiAND(4);
-    for (var i = 0; i < 4; i++) {
-        ranges_overlap[i].in[0] <== overlap_checks[i].out;
-    }
-
-    out <== ranges_overlap.out;
 }
 
 // Assumes boolean inputs


### PR DESCRIPTION
leaf: [a,b], sender specifies `recipient` and `c`. This implies, it is sending [a,c] to `recipient`. 

If c==b, the leaf is deleted and a new leaf is added for recipient. If c<d, leaf is updated with the new coin range and recipient leaf if added.

There are couple of places where force inclusion will create a problem (like Num2Bits). Will work on those in next PR.