### PR TITLE
honour force inclusion

### DIFF
--- a/circuits/circuits/mint.circom
+++ b/circuits/circuits/mint.circom
@@ -45,7 +45,7 @@ template Mint(levels, mintLevels) {
         pathIndices <== mintPathIndices
     );
 
-    // build a new tree by adding leaf to initial_root resulting in new_root.
+    // update the state tree by adding leaf to initial_root resulting in new_root.
     signal initial_root_calculated <== CheckMerkleProof(levels)(
         leaf <== 0,
         pathElements <== pathElements,

--- a/circuits/circuits/withdraw.circom
+++ b/circuits/circuits/withdraw.circom
@@ -31,9 +31,9 @@ template Withdraw(levels) {
 
     signal is_roots_equal <== IsEqual()(in <== [initial_root, initial_root_calculated]);
 
-    // delete the leaf and compute the new root.
+    // transfer the ownership of the withdrawn coins to zero address and compute the new root.
     signal root_with_deleted_leaf <== CheckMerkleProof(levels)(
-        leaf <== 0,
+        leaf <== Poseidon(3)(inputs <== [0, leaf_coins[0], leaf_coins[1]]),
         pathElements <== pathElements,
         pathIndices <== pathIndices
     );


### PR DESCRIPTION
As discussed offline, operator can bypass force send by passing in a leaf which doesn't contain `highest_coin_to_send`. In this case, the verifier returns the same `initial_root`.

As suggested, the fix is:
`force_include` ensures that `highest_coin_to_send < max_coin` AND any withdraw doesn't zero out the leaf but assigns zero address as the owner of that coin range. This ensures that there is always a leaf containing `highest_coin_to_send`. Now the verifier fails if the leaf doesn't contain `highest_coin_to_send`. This forces the prover to send the correct leaf.